### PR TITLE
Fix totalPago binding in venta payment modal

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -36,6 +36,16 @@ class GestionVenta extends Component
     public $listaSeleccionada = null;
     public $listasDescuento = [];
 
+    // Modal de pago
+    public $pago = [
+        'cuentaCorriente' => false,
+        'efectivo' => 0,
+        'tarjeta' => 0,
+        'otro' => 0,
+        'cheque' => 0,
+    ];
+
+    public $observacionesPago = '';
 
     // Totales discriminados
     public $subtotalSinIVA = 0;
@@ -304,6 +314,31 @@ class GestionVenta extends Component
     public function calcularTotal()
     {
         return $this->totalConIVA;
+    }
+
+    public function getTotalPagoProperty()
+    {
+        return collect($this->pago)->only(['efectivo', 'tarjeta', 'otro', 'cheque'])->sum();
+    }
+
+    public function abrirModalPago()
+    {
+        $this->dispatchBrowserEvent('show-modal-pago');
+    }
+
+    public function cerrarModalPago()
+    {
+        $this->dispatchBrowserEvent('hide-modal-pago');
+    }
+
+    public function confirmarPago()
+    {
+        Log::info('Pago registrado (pendiente de guardado).', [
+            'pago' => $this->pago,
+            'total_pago' => $this->totalPago,
+        ]);
+
+        $this->dispatchBrowserEvent('hide-modal-pago');
     }
 
     public function render()

--- a/resources/views/livewire/venta/gestion-venta.blade.php
+++ b/resources/views/livewire/venta/gestion-venta.blade.php
@@ -298,10 +298,88 @@
             </div>
 
             {{-- ================== BOTÓN DE GENERAR ================== --}}
-            <button class="btn btn-primary w-100 mt-3" wire:click="finalizarVenta">
+            <button class="btn btn-primary w-100 mt-3" wire:click="abrirModalPago">
                 Generar
             </button>
 
         </div>
     </div>
 </div>
+
+<div wire:ignore.self class="modal fade" id="modalPagoVenta" tabindex="-1" aria-labelledby="modalPagoVentaLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalPagoVentaLabel">Cierre de venta y método de pago</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar" wire:click="cerrarModalPago"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row g-3">
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Total venta</label>
+                        <input type="text" class="form-control" value="${{ number_format($totalConIVA, 2) }}" disabled>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Total pago</label>
+                        <input type="text" class="form-control" value="${{ number_format($this->totalPago, 2) }}" disabled>
+                    </div>
+                    <div class="col-12">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="pagoCuentaCorriente" wire:model="pago.cuentaCorriente">
+                            <label class="form-check-label" for="pagoCuentaCorriente">Cuenta Corriente</label>
+                        </div>
+                        <small class="text-muted">Marcar si el saldo queda a cuenta corriente.</small>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Efectivo</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.efectivo">
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Tarjeta</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.tarjeta">
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Cheque</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.cheque">
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Otro</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.otro">
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Observaciones</label>
+                        <textarea class="form-control" rows="3" wire:model.defer="observacionesPago"></textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal" wire:click="cerrarModalPago">
+                    Cancelar
+                </button>
+                <button type="button" class="btn btn-primary" wire:click="confirmarPago">
+                    Confirmar pago
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('custom-scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const modalElement = document.getElementById('modalPagoVenta');
+            if (!modalElement) {
+                return;
+            }
+            const modal = new bootstrap.Modal(modalElement);
+
+            window.addEventListener('show-modal-pago', () => {
+                modal.show();
+            });
+
+            window.addEventListener('hide-modal-pago', () => {
+                modal.hide();
+            });
+        });
+    </script>
+@endpush


### PR DESCRIPTION
### Motivation
- Fix an undefined variable error in the venta payment modal by binding the total payment value to the Livewire computed property and complete the UI flow to stage payment amounts before saving.

### Description
- Use the Livewire computed property by changing the blade binding to `{{ number_format($this->totalPago, 2) }}` to avoid `Undefined variable $totalPago` in `resources/views/livewire/venta/gestion-venta.blade.php`.
- Add a `$pago` state array and `observacionesPago` property to `app/Livewire/Venta/GestionVenta.php` to hold staged payment method amounts and notes.
- Implement `getTotalPagoProperty`, `abrirModalPago`, `cerrarModalPago`, and `confirmarPago` on the Livewire component and dispatch browser events for modal control and a logging stub in `confirmarPago`.
- Add a Bootstrap modal with inputs bound to `pago.*` and `observacionesPago`, change the `Generar` button to call `abrirModalPago`, and include frontend listeners that show/hide the modal on `show-modal-pago`/`hide-modal-pago` events.

### Testing
- No automated unit or feature tests were run for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684361e3208333adbbf3a0b0a26dc3)