### PR TITLE
Refine payment modal: quick-fill 'Pagar total' and cuenta corriente toggle

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -36,6 +36,16 @@ class GestionVenta extends Component
     public $listaSeleccionada = null;
     public $listasDescuento = [];
 
+    // Modal de pago
+    public $pago = [
+        'cuentaCorriente' => false,
+        'efectivo' => 0,
+        'tarjeta' => 0,
+        'otro' => 0,
+        'cheque' => 0,
+    ];
+
+    public $observacionesPago = '';
 
     // Totales discriminados
     public $subtotalSinIVA = 0;
@@ -304,6 +314,51 @@ class GestionVenta extends Component
     public function calcularTotal()
     {
         return $this->totalConIVA;
+    }
+
+    public function getTotalPagoProperty()
+    {
+        return collect($this->pago)->only(['efectivo', 'tarjeta', 'otro', 'cheque'])->sum();
+    }
+
+    public function abrirModalPago()
+    {
+        $this->dispatch('show-modal-pago');
+    }
+
+    public function cerrarModalPago()
+    {
+        $this->dispatch('hide-modal-pago');
+    }
+
+    public function confirmarPago()
+    {
+        Log::info('Pago registrado (pendiente de guardado).', [
+            'pago' => $this->pago,
+            'total_pago' => $this->totalPago,
+        ]);
+
+        $this->dispatch('hide-modal-pago');
+    }
+
+    public function aplicarPagoTotal($metodo)
+    {
+        $metodo = (string) $metodo;
+        if (!in_array($metodo, ['efectivo', 'tarjeta', 'cheque', 'otro'], true)) {
+            return;
+        }
+
+        $this->pago[$metodo] = round($this->totalConIVA, 2);
+    }
+
+    public function updatedPagoCuentaCorriente($value)
+    {
+        if ($value) {
+            $this->pago['efectivo'] = 0;
+            $this->pago['tarjeta'] = 0;
+            $this->pago['cheque'] = 0;
+            $this->pago['otro'] = 0;
+        }
     }
 
     public function render()

--- a/resources/views/livewire/venta/gestion-venta.blade.php
+++ b/resources/views/livewire/venta/gestion-venta.blade.php
@@ -1,3 +1,4 @@
+<div>
 <div class="container-fluid mt-4">
 
     {{-- FILTROS SUPERIORES --}}
@@ -298,10 +299,101 @@
             </div>
 
             {{-- ================== BOTÓN DE GENERAR ================== --}}
-            <button class="btn btn-primary w-100 mt-3" wire:click="finalizarVenta">
+            <button class="btn btn-primary w-100 mt-3" wire:click="abrirModalPago">
                 Generar
             </button>
 
         </div>
     </div>
+</div>
+
+<div wire:ignore.self class="modal fade" id="modalPagoVenta" tabindex="-1" aria-labelledby="modalPagoVentaLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalPagoVentaLabel">Cierre de venta y método de pago</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar" wire:click="cerrarModalPago"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row g-3">
+                    <div class="col-12">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="pagoCuentaCorriente" wire:model="pago.cuentaCorriente">
+                            <label class="form-check-label" for="pagoCuentaCorriente">Cuenta Corriente</label>
+                        </div>
+                        <small class="text-muted">Marcar si el saldo queda a cuenta corriente.</small>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Efectivo</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.efectivo" @readonly($pago['cuentaCorriente'])>
+                        <small class="text-info text-decoration-underline d-inline-block mt-1" role="button" style="cursor:pointer" wire:click="aplicarPagoTotal('efectivo')">
+                            Pagar total
+                        </small>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Tarjeta</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.tarjeta" @readonly($pago['cuentaCorriente'])>
+                        <small class="text-info text-decoration-underline d-inline-block mt-1" role="button" style="cursor:pointer" wire:click="aplicarPagoTotal('tarjeta')">
+                            Pagar total
+                        </small>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Cheque</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.cheque" @readonly($pago['cuentaCorriente'])>
+                        <small class="text-info text-decoration-underline d-inline-block mt-1" role="button" style="cursor:pointer" wire:click="aplicarPagoTotal('cheque')">
+                            Pagar total
+                        </small>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Otro</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.otro" @readonly($pago['cuentaCorriente'])>
+                        <small class="text-info text-decoration-underline d-inline-block mt-1" role="button" style="cursor:pointer" wire:click="aplicarPagoTotal('otro')">
+                            Pagar total
+                        </small>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Total venta</label>
+                        <input type="text" class="form-control fs-5 fw-bold" value="${{ number_format($totalConIVA, 2) }}" disabled>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Total pago</label>
+                        <input type="text" class="form-control fs-5 fw-bold" value="${{ number_format($this->totalPago, 2) }}" disabled>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Observaciones</label>
+                        <textarea class="form-control" rows="3" wire:model.defer="observacionesPago"></textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal" wire:click="cerrarModalPago">
+                    Cancelar
+                </button>
+                <button type="button" class="btn btn-primary" wire:click="confirmarPago">
+                    Confirmar pago
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('custom-scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const modalElement = document.getElementById('modalPagoVenta');
+            if (!modalElement) {
+                return;
+            }
+            const modal = new bootstrap.Modal(modalElement);
+
+            window.addEventListener('show-modal-pago', () => {
+                modal.show();
+            });
+
+            window.addEventListener('hide-modal-pago', () => {
+                modal.hide();
+            });
+        });
+    </script>
+@endpush
 </div>


### PR DESCRIPTION
### Motivation
- Visually replace the previous "Pagar total" buttons with a subtle clickable small text and make it clearer in the payment modal. 
- Ensure the quick-fill action not only highlights but immediately populates the associated payment input with the sale total to avoid manual typing. 
- When `Cuenta Corriente` is enabled, reset payment inputs and the total payment to zero and prevent editing until the switch is turned off. 

### Description
- Added a structured `$pago` array and `observacionesPago` property to `app/Livewire/Venta/GestionVenta.php` and implemented `getTotalPagoProperty`, `aplicarPagoTotal`, `updatedPagoCuentaCorriente`, `abrirModalPago`, `cerrarModalPago`, and `confirmarPago` handlers. 
- Updated the view `resources/views/livewire/venta/gestion-venta.blade.php` to replace the `Pagar total` buttons with clickable `<small>` text, make payment inputs `@readonly($pago['cuentaCorriente'])`, and wire the small text to `aplicarPagoTotal` so pressing it fills the corresponding input. 
- Added a payment modal that shows the payment inputs, `Total venta` and `Total pago` fields (emphasized), an observations textarea, and wired the main `Generar` button to open the modal via `abrirModalPago`. 
- Added client-side modal show/hide script that listens to dispatched events for `show-modal-pago` and `hide-modal-pago`. 

### Testing
- No automated tests were run for this UI-focused change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684361e3208333adbbf3a0b0a26dc3)