### PR TITLE
Vaciar valores de pago y deshabilitar Confirmar sin monto

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -36,6 +36,16 @@ class GestionVenta extends Component
     public $listaSeleccionada = null;
     public $listasDescuento = [];
 
+    // Modal de pago
+    public $pago = [
+        'cuentaCorriente' => false,
+        'efectivo' => 0,
+        'tarjeta' => 0,
+        'otro' => 0,
+        'cheque' => 0,
+    ];
+
+    public $observacionesPago = '';
 
     // Totales discriminados
     public $subtotalSinIVA = 0;
@@ -304,6 +314,114 @@ class GestionVenta extends Component
     public function calcularTotal()
     {
         return $this->totalConIVA;
+    }
+
+    public function getTotalPagoProperty()
+    {
+        return collect($this->pago)->only(['efectivo', 'tarjeta', 'otro', 'cheque'])->sum();
+    }
+
+    public function abrirModalPago()
+    {
+        $this->dispatch('show-modal-pago');
+    }
+
+    public function cerrarModalPago()
+    {
+        $this->dispatch('hide-modal-pago');
+    }
+
+    public function confirmarPago()
+    {
+        Log::info('Pago registrado (pendiente de guardado).', [
+            'pago' => $this->pago,
+            'total_pago' => $this->totalPago,
+        ]);
+
+        $this->dispatch('hide-modal-pago');
+    }
+
+    public function resetPago()
+    {
+        $this->pago['cuentaCorriente'] = false;
+        $this->pago['efectivo'] = 0;
+        $this->pago['tarjeta'] = 0;
+        $this->pago['cheque'] = 0;
+        $this->pago['otro'] = 0;
+    }
+
+    public function aplicarPagoTotal($metodo)
+    {
+        $metodo = (string) $metodo;
+        if (!in_array($metodo, ['efectivo', 'tarjeta', 'cheque', 'otro'], true)) {
+            return;
+        }
+
+        if ($this->pago['cuentaCorriente']) {
+            return;
+        }
+
+        $this->setPagoMetodo($metodo, $this->totalConIVA);
+    }
+
+    public function updatedPagoCuentaCorriente($value)
+    {
+        if ($value) {
+            $this->pago['efectivo'] = 0;
+            $this->pago['tarjeta'] = 0;
+            $this->pago['cheque'] = 0;
+            $this->pago['otro'] = 0;
+        }
+    }
+
+    public function updatedPagoEfectivo($value)
+    {
+        $this->syncPagoInput('efectivo', $value);
+    }
+
+    public function updatedPagoTarjeta($value)
+    {
+        $this->syncPagoInput('tarjeta', $value);
+    }
+
+    public function updatedPagoCheque($value)
+    {
+        $this->syncPagoInput('cheque', $value);
+    }
+
+    public function updatedPagoOtro($value)
+    {
+        $this->syncPagoInput('otro', $value);
+    }
+
+    private function syncPagoInput(string $metodo, $value): void
+    {
+        if ($this->pago['cuentaCorriente']) {
+            $this->pago[$metodo] = 0;
+            return;
+        }
+
+        $valor = is_numeric($value) ? (float) $value : 0;
+        $this->pago[$metodo] = max(0, round($valor, 2));
+    }
+
+    private function setPagoMetodo(string $metodo, $value): void
+    {
+        $valor = is_numeric($value) ? (float) $value : 0;
+        $valor = max(0, round($valor, 2));
+
+        foreach (['efectivo', 'tarjeta', 'cheque', 'otro'] as $key) {
+            $this->pago[$key] = $key === $metodo ? $valor : 0;
+        }
+    }
+
+    public function getPuedeConfirmarPagoProperty()
+    {
+        if ($this->pago['cuentaCorriente']) {
+            return true;
+        }
+
+        return $this->totalPago > 0;
     }
 
     public function render()

--- a/resources/views/livewire/venta/gestion-venta.blade.php
+++ b/resources/views/livewire/venta/gestion-venta.blade.php
@@ -1,3 +1,4 @@
+<div>
 <div class="container-fluid mt-4">
 
     {{-- FILTROS SUPERIORES --}}
@@ -298,10 +299,122 @@
             </div>
 
             {{-- ================== BOTÓN DE GENERAR ================== --}}
-            <button class="btn btn-primary w-100 mt-3" wire:click="finalizarVenta">
+            <button class="btn btn-primary w-100 mt-3" wire:click="abrirModalPago">
                 Generar
             </button>
 
         </div>
     </div>
+</div>
+
+<div wire:ignore.self class="modal fade" id="modalPagoVenta" tabindex="-1" aria-labelledby="modalPagoVentaLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalPagoVentaLabel">Cierre de venta y método de pago</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar" wire:click="cerrarModalPago"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row g-3">
+                    <div class="col-12">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="pagoCuentaCorriente" wire:model="pago.cuentaCorriente">
+                            <label class="form-check-label" for="pagoCuentaCorriente">Cuenta Corriente</label>
+                        </div>
+                        <small class="text-muted">Marcar si el saldo queda a cuenta corriente.</small>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Efectivo</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.efectivo" @readonly($pago['cuentaCorriente'])>
+                        @if($pago['cuentaCorriente'])
+                            <small class="text-muted d-inline-block mt-1">Pagar total</small>
+                        @else
+                            <small class="text-info text-decoration-underline d-inline-block mt-1" role="button" style="cursor:pointer" wire:click="aplicarPagoTotal('efectivo')">
+                                Pagar total
+                            </small>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Tarjeta</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.tarjeta" @readonly($pago['cuentaCorriente'])>
+                        @if($pago['cuentaCorriente'])
+                            <small class="text-muted d-inline-block mt-1">Pagar total</small>
+                        @else
+                            <small class="text-info text-decoration-underline d-inline-block mt-1" role="button" style="cursor:pointer" wire:click="aplicarPagoTotal('tarjeta')">
+                                Pagar total
+                            </small>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Cheque</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.cheque" @readonly($pago['cuentaCorriente'])>
+                        @if($pago['cuentaCorriente'])
+                            <small class="text-muted d-inline-block mt-1">Pagar total</small>
+                        @else
+                            <small class="text-info text-decoration-underline d-inline-block mt-1" role="button" style="cursor:pointer" wire:click="aplicarPagoTotal('cheque')">
+                                Pagar total
+                            </small>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Otro</label>
+                        <input type="number" min="0" step="0.01" class="form-control" wire:model.lazy="pago.otro" @readonly($pago['cuentaCorriente'])>
+                        @if($pago['cuentaCorriente'])
+                            <small class="text-muted d-inline-block mt-1">Pagar total</small>
+                        @else
+                            <small class="text-info text-decoration-underline d-inline-block mt-1" role="button" style="cursor:pointer" wire:click="aplicarPagoTotal('otro')">
+                                Pagar total
+                            </small>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Total venta</label>
+                        <input type="text" class="form-control fs-5 fw-bold" value="${{ number_format($totalConIVA, 2) }}" disabled>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label">Total pago</label>
+                        <input type="text" class="form-control fs-5 fw-bold" value="${{ number_format($this->totalPago, 2) }}" disabled>
+                    </div>
+                    <div class="col-12">
+                        <small class="text-info text-decoration-underline d-inline-block mt-2" role="button" style="cursor:pointer" wire:click="resetPago">
+                            Vaciar valores de pago
+                        </small>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Observaciones</label>
+                        <textarea class="form-control" rows="3" wire:model.defer="observacionesPago"></textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal" wire:click="cerrarModalPago">
+                    Cancelar
+                </button>
+                <button type="button" class="btn btn-primary" wire:click="confirmarPago" @disabled(!$this->puedeConfirmarPago)>
+                    Confirmar pago
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('custom-scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const modalElement = document.getElementById('modalPagoVenta');
+            if (!modalElement) {
+                return;
+            }
+            const modal = new bootstrap.Modal(modalElement);
+
+            window.addEventListener('show-modal-pago', () => {
+                modal.show();
+            });
+
+            window.addEventListener('hide-modal-pago', () => {
+                modal.hide();
+            });
+        });
+    </script>
+@endpush
 </div>


### PR DESCRIPTION
### Motivation
- Evitar estados inconsistentes en el modal de pago ofreciendo una acción que restablezca todos los inputs y el toggle de `cuentaCorriente` a su estado inicial. 
- Prevenir la confirmación de un pago sin montos ingresados cuando `cuentaCorriente` está deshabilitada para proteger la integridad del flujo de cierre de venta. 

### Description
- Se agregó el método `resetPago` en `app/Livewire/Venta/GestionVenta.php` que pone `pago.cuentaCorriente` a `false` y vacía `efectivo`, `tarjeta`, `cheque` y `otro` a `0`.
- Se introdujo la propiedad computada `getPuedeConfirmarPagoProperty` que habilita la confirmación solo si `pago.cuentaCorriente` está activo o si `totalPago` es mayor a `0`.
- En `resources/views/livewire/venta/gestion-venta.blade.php` se añadió el enlace visible `Vaciar valores de pago` que dispara `resetPago` y se añadió el atributo `@disabled(!$this->puedeConfirmarPago)` al botón `Confirmar pago` para bloquearlo según la nueva guardia.

### Testing
- No se ejecutaron pruebas automatizadas para estos cambios (cambios centrados en comportamiento/UX del modal).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684361e3208333adbbf3a0b0a26dc3)