### PR TITLE
Restringir añadir ítems y generación de venta hasta completar campos requeridos

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -193,6 +193,10 @@ class GestionVenta extends Component
 
     public function agregarCarrito()
 {
+    if (! $this->puedeAgregarItems) {
+        return;
+    }
+
     if (!$this->productoSeleccionado) return;
 
     $idProd = $this->productoSeleccionado->id;
@@ -323,6 +327,10 @@ class GestionVenta extends Component
 
     public function abrirModalPago()
     {
+        if (! $this->puedeGenerarVenta) {
+            return;
+        }
+
         $this->dispatch('show-modal-pago');
     }
 
@@ -422,6 +430,18 @@ class GestionVenta extends Component
         }
 
         return $this->totalPago > 0;
+    }
+
+    public function getPuedeAgregarItemsProperty()
+    {
+        return !empty($this->tipoComprobante)
+            && !empty($this->cliente)
+            && !empty($this->vendedor);
+    }
+
+    public function getPuedeGenerarVentaProperty()
+    {
+        return count($this->carrito) > 0;
     }
 
     public function render()

--- a/resources/views/livewire/venta/gestion-venta.blade.php
+++ b/resources/views/livewire/venta/gestion-venta.blade.php
@@ -204,9 +204,14 @@
                 </div>
             </div>
             
-            <button class="btn btn-success w-100 mb-3" wire:click="agregarCarrito">
+            <button class="btn btn-success w-100 mb-3" wire:click="agregarCarrito" @disabled(! $this->puedeAgregarItems)>
                 Añadir
             </button>
+            @unless($this->puedeAgregarItems)
+                <small class="text-muted d-block text-center mb-3">
+                    Seleccione tipo de comprobante, cliente y vendedor para añadir al carrito.
+                </small>
+            @endunless
         @endif
 
             <table class="table table-sm align-middle">
@@ -299,7 +304,7 @@
             </div>
 
             {{-- ================== BOTÓN DE GENERAR ================== --}}
-            <button class="btn btn-primary w-100 mt-3" wire:click="abrirModalPago">
+            <button class="btn btn-primary w-100 mt-3" wire:click="abrirModalPago" @disabled(! $this->puedeGenerarVenta)>
                 Generar
             </button>
 


### PR DESCRIPTION
### Motivation
- Forzar que el flujo de creación de venta respete validaciones UI: el usuario debe seleccionar un `tipo de comprobante`, un `cliente` y un `vendedor` antes de poder añadir ítems, y solo podrá presionar `Generar` si hay al menos 1 producto en el carrito.

### Description
- Se añadieron getters de permiso (`getPuedeAgregarItemsProperty`, `getPuedeGenerarVentaProperty`) y checks iniciales en `agregarCarrito` y `abrirModalPago` para bloquear la acción cuando no se cumplen las condiciones, y se deshabilitaron los botones y se mostró un texto guía en la vista; archivos modificados: `app/Livewire/Venta/GestionVenta.php` y `resources/views/livewire/venta/gestion-venta.blade.php`.

### Testing
- No se ejecutaron pruebas automatizadas (ninguna prueba corrida durante este cambio).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968711c614083339041f802ff186111)