### PR TITLE
Agregar atajo Enter para seleccionar producto único en búsqueda

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -151,6 +151,17 @@ class GestionVenta extends Component
         }
     }
 
+    public function seleccionarProductoUnico(): void
+    {
+        $this->buscarProductos();
+
+        if (! $this->productos || $this->productos->count() !== 1) {
+            return;
+        }
+
+        $this->seleccionarProducto($this->productos->first()->id);
+    }
+
     public function seleccionarProducto($id)
     {
         $this->productoSeleccionado = Producto::find($id);

--- a/resources/views/livewire/venta/gestion-venta.blade.php
+++ b/resources/views/livewire/venta/gestion-venta.blade.php
@@ -69,7 +69,7 @@
             </div>
 
             <input type="text" class="form-control mb-3" placeholder="🔎 Buscar por nombre o escanear código de barras…"
-            wire:model.live="buscador">
+            wire:model.live="buscador" wire:keydown.enter.prevent="seleccionarProductoUnico">
 
             <div class="border p-2" style="min-height:250px;">
             <table class="table table-sm table-hover">


### PR DESCRIPTION
### Motivation
- Agilizar la operación del usuario permitiendo que al presionar Enter en el campo de búsqueda, si la búsqueda devuelve exactamente un producto, se seleccione automáticamente y se muestre en el panel derecho para añadirlo al carrito.

### Description
- Se añadió el método `seleccionarProductoUnico` en `app/Livewire/Venta/GestionVenta.php` y se conectó el input de búsqueda en `resources/views/livewire/venta/gestion-venta.blade.php` con `wire:keydown.enter.prevent="seleccionarProductoUnico"` para ejecutar la selección cuando exista un único resultado.

### Testing
- No se ejecutaron pruebas automatizadas en esta rama.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696872935d5483339c164f5ab597ed4a)