### PR TITLE
Validación y feedback en modal de pago de venta

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -336,6 +336,11 @@ class GestionVenta extends Component
         return collect($this->pago)->only(['efectivo', 'tarjeta', 'otro', 'cheque'])->sum();
     }
 
+    public function getSaldoPendienteProperty()
+    {
+        return round($this->totalConIVA - $this->totalPago, 2);
+    }
+
     public function abrirModalPago()
     {
         if (! $this->puedeGenerarVenta) {
@@ -352,6 +357,10 @@ class GestionVenta extends Component
 
     public function confirmarPago()
     {
+        if (! $this->validarPago()) {
+            return;
+        }
+
         Log::info('Pago registrado (pendiente de guardado).', [
             'pago' => $this->pago,
             'total_pago' => $this->totalPago,
@@ -368,6 +377,7 @@ class GestionVenta extends Component
         $this->pago['cheque'] = 0;
         $this->pago['otro'] = 0;
         $this->observacionesPago = '';
+        $this->resetErrorBag('pago_total');
     }
 
     public function aplicarPagoTotal($metodo)
@@ -392,6 +402,8 @@ class GestionVenta extends Component
             $this->pago['cheque'] = 0;
             $this->pago['otro'] = 0;
         }
+
+        $this->resetErrorBag('pago_total');
     }
 
     public function updatedPagoEfectivo($value)
@@ -423,6 +435,7 @@ class GestionVenta extends Component
 
         $valor = is_numeric($value) ? (float) $value : 0;
         $this->pago[$metodo] = max(0, round($valor, 2));
+        $this->resetErrorBag('pago_total');
     }
 
     private function setPagoMetodo(string $metodo, $value): void
@@ -441,7 +454,28 @@ class GestionVenta extends Component
             return true;
         }
 
-        return $this->totalPago > 0;
+        return $this->totalPago > 0 && $this->pagoCompleto();
+    }
+
+    private function pagoCompleto(): bool
+    {
+        return abs($this->totalConIVA - $this->totalPago) < 0.01;
+    }
+
+    private function validarPago(): bool
+    {
+        $this->resetErrorBag('pago_total');
+
+        if ($this->pago['cuentaCorriente']) {
+            return true;
+        }
+
+        if (! $this->pagoCompleto()) {
+            $this->addError('pago_total', 'El total abonado debe coincidir con el total de la venta.');
+            return false;
+        }
+
+        return true;
     }
 
     public function getPuedeAgregarItemsProperty()

--- a/resources/views/livewire/venta/gestion-venta.blade.php
+++ b/resources/views/livewire/venta/gestion-venta.blade.php
@@ -381,6 +381,29 @@
                         <input type="text" class="form-control fs-5 fw-bold" value="${{ number_format($this->totalPago, 2) }}" disabled>
                     </div>
                     <div class="col-12">
+                        @if($pago['cuentaCorriente'])
+                            <div class="alert alert-info py-2 mb-0">
+                                Saldo a cuenta corriente: <strong>${{ number_format($totalConIVA, 2) }}</strong>
+                            </div>
+                        @else
+                            @php
+                                $saldoPendiente = $this->saldoPendiente;
+                            @endphp
+                            <div class="alert {{ $saldoPendiente === 0.0 ? 'alert-success' : ($saldoPendiente > 0 ? 'alert-warning' : 'alert-danger') }} py-2 mb-0">
+                                @if($saldoPendiente === 0.0)
+                                    Pago completo.
+                                @elseif($saldoPendiente > 0)
+                                    Falta abonar: <strong>${{ number_format($saldoPendiente, 2) }}</strong>
+                                @else
+                                    Exceso de pago: <strong>${{ number_format(abs($saldoPendiente), 2) }}</strong>
+                                @endif
+                            </div>
+                        @endif
+                        @error('pago_total')
+                            <div class="text-danger mt-2">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <div class="col-12">
                         <small class="text-info text-decoration-underline d-inline-block mt-2" role="button" style="cursor:pointer" wire:click="resetPago">
                             Vaciar valores de pago
                         </small>


### PR DESCRIPTION
### Motivation
- Corregir fallos de integridad y usabilidad en la ventana modal de pagos para que el flujo sea natural: impedir confirmar cuando los montos no coinciden y mostrar el saldo pendiente/exceso o marcar como cuenta corriente.

### Description
- Agrega la propiedad calculada `getSaldoPendienteProperty()` y el helper `pagoCompleto()` para comparar el total de la venta con los pagos.
- Implementa `validarPago()` y bloquea `confirmarPago()` cuando el total abonado no coincide con el total de la venta (salvo `cuentaCorriente`).
- Limpia errores de validación relevantes con `resetErrorBag('pago_total')` al actualizar inputs, cambiar a cuenta corriente o al resetear el pago.
- Añade feedback visual en la vista `resources/views/livewire/venta/gestion-venta.blade.php` para mostrar estado del saldo (pago completo / falta abonar / exceso) y mensajes de error bajo el modal.

### Testing
- No se ejecutaron pruebas automatizadas de `phpunit` en este cambio.
- Intenté levantar la aplicación con `php artisan serve`, pero falló por falta de dependencias (`vendor/autoload.php` ausente), por lo que no fue posible validar la UI en ejecución.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968735d321c83338ea02a5ed5246261)