### PR TITLE
Actualizar lógica al agregar productos duplicados al carrito

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -228,7 +228,7 @@ class GestionVenta extends Component
         $this->carrito[$index]['cantidad'] += (int) $this->cantidad;
 
         $cantidadTotal = $this->carrito[$index]['cantidad'];
-        $descuento = $this->carrito[$index]['descuento'];
+        $descuento = (float) $this->descuento;
 
         // Recalcular totales
         $subConIVA = $precioConIVA * $cantidadTotal;
@@ -241,6 +241,9 @@ class GestionVenta extends Component
         }
 
         // Actualizar carrito
+        $this->carrito[$index]['precio'] = $precioConIVA;
+        $this->carrito[$index]['precio_sin_iva'] = $precioSinIVA;
+        $this->carrito[$index]['descuento'] = $descuento;
         $this->carrito[$index]['subtotal_con_iva'] = round($subConIVA, 2);
         $this->carrito[$index]['subtotal_sin_iva'] = round($subSinIVA, 2);
         $this->carrito[$index]['subtotal']         = round($subConIVA, 2); // compatibilidad


### PR DESCRIPTION
### Motivation
- Al volver a añadir un producto ya presente en el carrito se debe aplicar la información actual (precio y descuento) y recalcular subtotales para evitar mantener valores obsoletos.

### Description
- En `app/Livewire/Venta/GestionVenta.php` al detectar un producto duplicado ahora se suma la cantidad y se usa el descuento actual (`$this->descuento`) casteado a `float` para el recálculo de subtotales.
- Se actualizan las claves del ítem en carrito `precio`, `precio_sin_iva` y `descuento` con los valores actuales antes de recalcular `subtotal_con_iva` y `subtotal_sin_iva`.
- Se mantiene la rama existente que añade productos nuevos sin cambios funcionales aparte de la coherencia del cálculo.

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio (ninguna `phpunit` u otra suite fue corrída).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696876701c9c8333ae60f35a9461a40e)