### PR TITLE
Prevenir redeclaración de funciones helper

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,13 +1,19 @@
 <?php
   
-function active_class($path, $active = 'active') {
-  return call_user_func_array('Request::is', (array)$path) ? $active : '';
+if (!function_exists('active_class')) {
+  function active_class($path, $active = 'active') {
+    return call_user_func_array('Request::is', (array)$path) ? $active : '';
+  }
 }
 
-function is_active_route($path) {
-  return call_user_func_array('Request::is', (array)$path) ? 'true' : 'false';
+if (!function_exists('is_active_route')) {
+  function is_active_route($path) {
+    return call_user_func_array('Request::is', (array)$path) ? 'true' : 'false';
+  }
 }
 
-function show_class($path) {
-  return call_user_func_array('Request::is', (array)$path) ? 'show' : '';
+if (!function_exists('show_class')) {
+  function show_class($path) {
+    return call_user_func_array('Request::is', (array)$path) ? 'show' : '';
+  }
 }


### PR DESCRIPTION
### Motivation
- Evitar el error fatal `Cannot redeclare active_class()` que ocurre cuando `app/helpers.php` se carga varias veces al redifinir las mismas funciones.

### Description
- Envuelve las definiciones de las funciones helper con comprobaciones `if (!function_exists(...))` para `active_class`, `is_active_route` y `show_class`.
- Se actualizó el archivo `app/helpers.php` para aplicar estas guardas y así evitar redeclaraciones.

### Testing
- No se ejecutaron pruebas automáticas sobre este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696871917f148333b7b090be0708d6ff)