### PR TITLE
Keep product input panel visible; disable fields until product selected

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -31,8 +31,8 @@ class GestionVenta extends Component
     // Carrito
     public $carrito = [];
     public $productoSeleccionado = null;
-    public $cantidad = 1;
-    public $descuento = 0;
+    public $cantidad = null;
+    public $descuento = null;
     public $listaSeleccionada = null;
     public $listasDescuento = [];
 
@@ -53,8 +53,8 @@ class GestionVenta extends Component
     public $totalConIVA = 0;
 
     protected $rules = [
-        'cantidad' => 'integer|min:1',
-        'descuento' => 'numeric|min:0'
+        'cantidad' => 'nullable|integer|min:1',
+        'descuento' => 'nullable|numeric|min:0'
     ];
 
     public function mount()
@@ -187,6 +187,11 @@ class GestionVenta extends Component
         if (!$value) {
             return;
         }
+
+        if (! $this->productoSeleccionado) {
+            $this->descuento = null;
+            return;
+        }
         Log::info('Lista seleccionada - nombre: ' . $value);
         // FORZAR que la comparación no falle por tipo
         $lista = collect($this->listasDescuento)
@@ -277,12 +282,17 @@ class GestionVenta extends Component
     }
 
     // Reset selección
-    $this->productoSeleccionado = null;
-    $this->cantidad = 1;
-    $this->descuento = 0;
+    $this->resetSeleccionProducto();
 
     // Recalcular totales generales
     $this->actualizarTotales();
+    }
+
+    public function resetSeleccionProducto()
+    {
+        $this->productoSeleccionado = null;
+        $this->cantidad = null;
+        $this->descuento = null;
     }
 
     public function actualizarItem($index)

--- a/front/dashboard.component.html
+++ b/front/dashboard.component.html
@@ -294,11 +294,11 @@
               </ng-select>
               <small class="text-muted">* Presione la tecla [F8] para acceder rápidamente a la búsqueda</small>
             </div>            
-            <div class="row py-4 mt-2" *ngIf="selectedSearchProductId">
+            <div class="row py-4 mt-2">
               
               <div class="row">
                 <div class="col-4 d-flex align-items-center">
-                  {{selectedProduct.nametoShow}}
+                  {{selectedProduct?.nametoShow}}
                 </div>
                 <div class="col-4 d-flex align-items-center">
                   Precio: $ {{precio}}
@@ -309,7 +309,7 @@
                     <label for="cantidad" class="col-5 col-form-label">Cantidad:</label>
                     <div class="col-4 px-0 d-flex justify-content-start">
                       <input class="form-control" name="cantidad" type="number" placeholder="Cantidad" 
-                      [(ngModel)]="cantidad" (change)="cantidadChange()" min="0" onkeypress="return event.charCode != 44"/>
+                      [(ngModel)]="cantidad" (change)="cantidadChange()" min="0" [disabled]="!selectedSearchProductId" onkeypress="return event.charCode != 44"/>
                     </div>
                   </div>
                 </div>
@@ -325,7 +325,7 @@
                               <p>%</p>
                           </button>
                           <input class="form-control" name="descuento" type="number" 
-                          [(ngModel)]="descuento" (change)="descuentoChange()" min="0" onkeypress="return event.charCode != 44"/>
+                          [(ngModel)]="descuento" (change)="descuentoChange()" min="0" [disabled]="!selectedSearchProductId" onkeypress="return event.charCode != 44"/>
                         </div>  
                       </div>
                     </div>
@@ -336,7 +336,7 @@
                 </div>
 
                 <div class="col-4 d-flex align-items-center justify-content-start">
-                  <button class="btn btn-primary" [disabled]="!selectedCliente" (click)="addProductClick()">Agregar</button>
+                  <button class="btn btn-primary" *ngIf="selectedSearchProductId" [disabled]="!selectedCliente" (click)="addProductClick()">Agregar</button>
                 </div>
                 
               </div>

--- a/front/dashboard.component.ts
+++ b/front/dashboard.component.ts
@@ -93,17 +93,17 @@ export class DashboardComponent implements OnInit {
   productos: Producto[] = [];
   productosToShow: Producto[] = [];
   selectedSearchProductId: number;
-  selectedProduct: Producto;
+  selectedProduct: Producto | null;
   register: RegisterDto;
   confirmationMessage: string = "";
   registerId: number;
   optionsModal: NgbActiveModal;
 
   //productos
-  cantidad: number = 1;
+  cantidad: number | null = null;
   precio: string = "";
   ganancia: number = 0;
-  descuento: number = 0;
+  descuento: number | null = null;
   subtotal: string = "";
   precioXUnidad: string = "";
   test = false;
@@ -293,12 +293,15 @@ export class DashboardComponent implements OnInit {
 
   onProductSelected() {
     if (this.selectedSearchProductId) {
+      this.cantidad = 1;
       this.descuento = 0;
       const foundProduct = this.productos.find(prod => prod.id == this.selectedSearchProductId);
       this.selectedProduct = { ...foundProduct };
       const foundMarca = this.marcas.find(mar => mar.id == this.selectedProduct.id_marca);
       this.selectedProduct.nametoShow = foundMarca ? foundMarca.nombre + " - " + this.selectedProduct.nombre : this.selectedProduct.nombre;
       this.calculateProductPrice();
+    } else {
+      this.resetSelectedProductDetails();
     }
   }
 
@@ -344,7 +347,7 @@ export class DashboardComponent implements OnInit {
 
     if (this.selectedProduct) {
       const subtotal = this.getCalculatedPrice(this.selectedProduct.precio_costo_final,
-        this.cantidad, this.ganancia, this.descuento);
+        this.cantidad ?? 0, this.ganancia, this.descuento ?? 0);
       this.subtotal = subtotal.toFixed(1)
     }
   }
@@ -452,10 +455,10 @@ export class DashboardComponent implements OnInit {
   addProductClick() {
     let product = new ProductDto();
     product.id = this.selectedProduct.id;
-    product.cantidad = this.cantidad;
+    product.cantidad = this.cantidad ?? 0;
     product.descripcion = this.selectedProduct.nombre;
     product.idLista = this.selectedCliente.id_lista;
-    product.descuentoPorcentual = this.descuento;
+    product.descuentoPorcentual = this.descuento ?? 0;
     product.descuentoNominal = 0;
     product.precioUnitarioOriginal = this.selectedProduct.precio_costo_final;
     product.precioUnitario = this.selectedProduct.precio_costo_final;
@@ -512,8 +515,16 @@ export class DashboardComponent implements OnInit {
 
   resetProduct() {
     this.selectedSearchProductId = null;
-    this.cantidad = 1;
-    this.descuento = 0;
+    this.resetSelectedProductDetails();
+  }
+
+  resetSelectedProductDetails() {
+    this.selectedProduct = null;
+    this.cantidad = null;
+    this.descuento = null;
+    this.precio = "";
+    this.precioXUnidad = "";
+    this.subtotal = "";
   }
 
   updateProductValues(row: ProductDto) {
@@ -840,8 +851,6 @@ export class DashboardComponent implements OnInit {
     //this.content = replaceText
   }
 }
-
-
 
 
 

--- a/resources/views/livewire/venta/gestion-venta.blade.php
+++ b/resources/views/livewire/venta/gestion-venta.blade.php
@@ -149,37 +149,38 @@
         {{-- ================== DERECHA ================== --}}
         <div class="col-12 col-lg-6 p-3 border rounded">
 
-            @if($productoSeleccionado)
-
             {{-- NOMBRE DEL PRODUCTO --}}
             <div class="text-center mb-2">
-                <h5 class="fw-bold">{{ $productoSeleccionado->nombre }}</h5>
+                <h5 class="fw-bold">{{ $productoSeleccionado?->nombre ?? '' }}</h5>
             </div>
 
             {{-- PRECIO ACTUAL --}} 
             <div class="text-center mb-3">
+                @if($productoSeleccionado)
+                    @if($productoSeleccionado->isOffer())
+                        {{-- Precio normal tachado --}}
+                        <div class="text-muted" style="text-decoration: line-through;">
+                            ${{ number_format($productoSeleccionado->precio_pesos_con_iva, 2) }}
+                        </div>
 
-                @if($productoSeleccionado->isOffer())
-                    {{-- Precio normal tachado --}}
-                    <div class="text-muted" style="text-decoration: line-through;">
-                        ${{ number_format($productoSeleccionado->precio_pesos_con_iva, 2) }}
-                    </div>
-
-                    {{-- Precio con oferta --}}
-                    <div class="fw-bold text-success" style="font-size: 1.2rem;">
-                        ${{ number_format($productoSeleccionado->precio_costo_oferta, 1) }}
-                    </div>
+                        {{-- Precio con oferta --}}
+                        <div class="fw-bold text-success" style="font-size: 1.2rem;">
+                            ${{ number_format($productoSeleccionado->precio_costo_oferta, 1) }}
+                        </div>
+                    @else
+                        <div class="fw-bold" style="font-size: 1.2rem;">
+                            ${{ number_format($productoSeleccionado->precio_pesos_con_iva, 2) }}
+                        </div>
+                    @endif
                 @else
-                    <div class="fw-bold" style="font-size: 1.2rem;">
-                        ${{ number_format($productoSeleccionado->precio_pesos_con_iva, 2) }}
-                    </div>
+                    <div class="text-muted" style="font-size: 1.2rem;">&nbsp;</div>
                 @endif
             </div>
 
             {{-- LISTA DE DESCUENTOS --}}
             <div class="row mb-3">
                 <div class="col-4">
-                    <input type="number" min="1" class="form-control" wire:model="cantidad">
+                    <input type="number" min="1" class="form-control" wire:model="cantidad" @disabled(! $productoSeleccionado)>
                     <small>Cantidad</small>
                 </div>
                 <div class="col-4">
@@ -188,11 +189,12 @@
                         class="form-control" 
                         wire:model="descuento"
                         wire:key="descuento-{{ $listaSeleccionada }}-{{ $productoSeleccionado->id ?? 0 }}"
+                        @disabled(! $productoSeleccionado)
                     >
                     <small>Descuento %</small>
                 </div>
                 <div class="col-4">
-                    <select class="form-select" wire:model.change="listaSeleccionada">
+                    <select class="form-select" wire:model.change="listaSeleccionada" @disabled(! $productoSeleccionado)>
                         <option value="">Lista descuento...</option>
 
                         @foreach($listasDescuento as $lista)
@@ -204,15 +206,16 @@
                 </div>
             </div>
             
-            <button class="btn btn-success w-100 mb-3" wire:click="agregarCarrito" @disabled(! $this->puedeAgregarItems)>
-                Añadir
-            </button>
-            @unless($this->puedeAgregarItems)
-                <small class="text-muted d-block text-center mb-3">
-                    Seleccione tipo de comprobante, cliente y vendedor para añadir al carrito.
-                </small>
-            @endunless
-        @endif
+            @if($productoSeleccionado)
+                <button class="btn btn-success w-100 mb-3" wire:click="agregarCarrito" @disabled(! $this->puedeAgregarItems)>
+                    Añadir
+                </button>
+                @unless($this->puedeAgregarItems)
+                    <small class="text-muted d-block text-center mb-3">
+                        Seleccione tipo de comprobante, cliente y vendedor para añadir al carrito.
+                    </small>
+                @endunless
+            @endif
 
             <table class="table table-sm align-middle">
     <thead>


### PR DESCRIPTION
### Motivation
- Mantener siempre visible el panel de entrada de producto en la derecha aunque no haya producto seleccionado y evitar inputs activos/valores inválidos cuando no hay selección. 
- Ocultar el botón `Añadir` salvo cuando haya un producto seleccionado y limpiar los campos al deseleccionar o tras agregar. 
- Soportar valores vacíos controlados usando `null` para `cantidad`/`descuento` y evitar actualizaciones de descuento cuando no hay producto activo.

### Description
- Siempre renderiza el panel de producto en la vista Livewire y muestra el nombre con navegación segura usando `{{ $productoSeleccionado?->nombre ?? '' }}`, además de deshabilitar inputs con `@disabled(! $productoSeleccionado)` y condicionar el botón `Añadir` a la existencia de `productoSeleccionado` (`resources/views/livewire/venta/gestion-venta.blade.php`).
- Cambia `app/Livewire/Venta/GestionVenta.php` para usar `public $cantidad = null` y `public $descuento = null`, adapta las reglas de validación a `nullable|...`, añade `resetSeleccionProducto()` para limpiar la selección y evita aplicar la `listaSeleccionada` cuando no hay producto seleccionado en `updatedListaSeleccionada()`.
- Frontend: deja visible el bloque de producto en `front/dashboard.component.html`, usar `{{selectedProduct?.nametoShow}}`, deshabilitar los inputs cuando `!selectedSearchProductId` y mostrar el botón `Agregar` sólo si `selectedSearchProductId` está presente.
- Actualiza `front/dashboard.component.ts` para declarar `selectedProduct: Producto | null`, `cantidad` y `descuento` como `null` por defecto, inicializarlos al seleccionar producto, y añadir `resetSelectedProductDetails()` que limpia `selectedProduct`, `cantidad`, `descuento`, `precio`, `precioXUnidad` y `subtotal` cuando se deselecciona.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976be21528483338bfa3b810a88e04f)