### PR TITLE
Sumar cantidades al re-agregar items y normalizar comparación de IDs (preserva lista de descuento)

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -211,13 +211,25 @@ class GestionVenta extends Component
     if (!$this->productoSeleccionado) return;
 
     $idProd = $this->productoSeleccionado->id;
+    $listaId = $this->listaSeleccionada ? (int) $this->listaSeleccionada : null;
+    $descuento = (float) $this->descuento;
+
+    if ($listaId) {
+        $lista = collect($this->listasDescuento)->first(fn($l) => (int) $l->id === $listaId);
+
+        if ($lista) {
+            $descuento = (float) $lista->valor;
+        }
+    }
 
     // Precios base
     $precioConIVA = $this->productoSeleccionado->PrecioPesosConIva;
     $precioSinIVA  = $this->productoSeleccionado->getPrecioEnPesos();
 
     // Buscar si ya existe en el carrito
-    $index = collect($this->carrito)->search(fn($p) => $p['id'] === $idProd);
+    $index = collect($this->carrito)->search(
+        fn($p) => (string) $p['id'] === (string) $idProd
+    );
 
     // ============================================================
     //   CASO 1: EL PRODUCTO YA ESTÁ EN EL CARRITO → SUMAR CANTIDAD
@@ -228,8 +240,6 @@ class GestionVenta extends Component
         $this->carrito[$index]['cantidad'] += (int) $this->cantidad;
 
         $cantidadTotal = $this->carrito[$index]['cantidad'];
-        $descuento = (float) $this->descuento;
-
         // Recalcular totales
         $subConIVA = $precioConIVA * $cantidadTotal;
         $subSinIVA = $precioSinIVA * $cantidadTotal;
@@ -244,6 +254,7 @@ class GestionVenta extends Component
         $this->carrito[$index]['precio'] = $precioConIVA;
         $this->carrito[$index]['precio_sin_iva'] = $precioSinIVA;
         $this->carrito[$index]['descuento'] = $descuento;
+        $this->carrito[$index]['lista_descuento_id'] = $listaId;
         $this->carrito[$index]['subtotal_con_iva'] = round($subConIVA, 2);
         $this->carrito[$index]['subtotal_sin_iva'] = round($subSinIVA, 2);
         $this->carrito[$index]['subtotal']         = round($subConIVA, 2); // compatibilidad
@@ -257,8 +268,8 @@ class GestionVenta extends Component
         $subtotalConIVA = $precioConIVA * $this->cantidad;
         $subtotalSinIVA = $precioSinIVA * $this->cantidad;
 
-        if ($this->descuento > 0) {
-            $factor = (1 - ($this->descuento / 100));
+        if ($descuento > 0) {
+            $factor = (1 - ($descuento / 100));
             $subtotalConIVA *= $factor;
             $subtotalSinIVA *= $factor;
         }
@@ -269,7 +280,8 @@ class GestionVenta extends Component
             'precio' => $precioConIVA,
             'precio_sin_iva' => $precioSinIVA,
             'cantidad' => (int) $this->cantidad,
-            'descuento' => (float) $this->descuento,
+            'descuento' => $descuento,
+            'lista_descuento_id' => $listaId,
             'subtotal_con_iva' => round($subtotalConIVA, 2),
             'subtotal_sin_iva' => round($subtotalSinIVA, 2),
             'subtotal' => round($subtotalConIVA, 2), // compatibilidad


### PR DESCRIPTION
### Motivation
- Garantizar que al volver a añadir un producto al carrito se acumulen las cantidades previamente ingresadas en lugar de reemplazarlas.
- Asegurar que el `descuento` efectivo use la `listaSeleccionada` cuando exista para evitar inconsistencias en subtotales.
- Mantener la referencia a `lista_descuento_id` en cada ítem para trazabilidad y cálculos posteriores.

### Description
- Se actualizó `app/Livewire/Venta/GestionVenta.php` para resolver el `descuento` efectivo priorizando la `listaSeleccionada` y almacenarlo en la variable local `$descuento` usada en ambos casos (item nuevo y existente). 
- La búsqueda del producto en el carrito ahora normaliza los IDs con `(string)` para evitar fallos cuando los IDs llegan como `string` desde Livewire y así permitir sumar cantidades correctamente (`collect($this->carrito)->search(fn($p) => (string)$p['id'] === (string)$idProd)`).
- Al re-agregar un producto existente se suma la nueva `cantidad` a la anterior, se recalculan subtotales aplicando el `descuento` efectivo y se actualizan `descuento` y `lista_descuento_id` en el ítem.
- Al crear un nuevo ítem se guardan `descuento` y `lista_descuento_id`, y los subtotales se calculan usando el `descuento` resuelto; se mantienen los reseteos de selección y la llamada a `actualizarTotales()`.

### Testing
- No se ejecutaron pruebas automatizadas en esta rama (ninguna prueba automática fue solicitada ni corrida).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976cc5cc34483338a9830c98f2d902a)