### PR TITLE
Respetar descuento manual al re-agregar y preservar lista_descuento_id

### DIFF
--- a/app/Livewire/Venta/GestionVenta.php
+++ b/app/Livewire/Venta/GestionVenta.php
@@ -211,13 +211,17 @@ class GestionVenta extends Component
     if (!$this->productoSeleccionado) return;
 
     $idProd = $this->productoSeleccionado->id;
+    $listaId = $this->listaSeleccionada ? (int) $this->listaSeleccionada : null;
+    $descuento = (float) $this->descuento;
 
     // Precios base
     $precioConIVA = $this->productoSeleccionado->PrecioPesosConIva;
     $precioSinIVA  = $this->productoSeleccionado->getPrecioEnPesos();
 
     // Buscar si ya existe en el carrito
-    $index = collect($this->carrito)->search(fn($p) => $p['id'] === $idProd);
+    $index = collect($this->carrito)->search(
+        fn($p) => (string) $p['id'] === (string) $idProd
+    );
 
     // ============================================================
     //   CASO 1: EL PRODUCTO YA ESTÁ EN EL CARRITO → SUMAR CANTIDAD
@@ -228,8 +232,6 @@ class GestionVenta extends Component
         $this->carrito[$index]['cantidad'] += (int) $this->cantidad;
 
         $cantidadTotal = $this->carrito[$index]['cantidad'];
-        $descuento = (float) $this->descuento;
-
         // Recalcular totales
         $subConIVA = $precioConIVA * $cantidadTotal;
         $subSinIVA = $precioSinIVA * $cantidadTotal;
@@ -244,6 +246,7 @@ class GestionVenta extends Component
         $this->carrito[$index]['precio'] = $precioConIVA;
         $this->carrito[$index]['precio_sin_iva'] = $precioSinIVA;
         $this->carrito[$index]['descuento'] = $descuento;
+        $this->carrito[$index]['lista_descuento_id'] = $listaId;
         $this->carrito[$index]['subtotal_con_iva'] = round($subConIVA, 2);
         $this->carrito[$index]['subtotal_sin_iva'] = round($subSinIVA, 2);
         $this->carrito[$index]['subtotal']         = round($subConIVA, 2); // compatibilidad
@@ -257,8 +260,8 @@ class GestionVenta extends Component
         $subtotalConIVA = $precioConIVA * $this->cantidad;
         $subtotalSinIVA = $precioSinIVA * $this->cantidad;
 
-        if ($this->descuento > 0) {
-            $factor = (1 - ($this->descuento / 100));
+        if ($descuento > 0) {
+            $factor = (1 - ($descuento / 100));
             $subtotalConIVA *= $factor;
             $subtotalSinIVA *= $factor;
         }
@@ -269,7 +272,8 @@ class GestionVenta extends Component
             'precio' => $precioConIVA,
             'precio_sin_iva' => $precioSinIVA,
             'cantidad' => (int) $this->cantidad,
-            'descuento' => (float) $this->descuento,
+            'descuento' => $descuento,
+            'lista_descuento_id' => $listaId,
             'subtotal_con_iva' => round($subtotalConIVA, 2),
             'subtotal_sin_iva' => round($subtotalSinIVA, 2),
             'subtotal' => round($subtotalConIVA, 2), // compatibilidad


### PR DESCRIPTION
### Motivation
- Evitar que el `descuento` ingresado manualmente sea sobrescrito al volver a agregar el mismo producto al carrito. 
- Garantizar que al re-agregar un producto se acumulen las cantidades y que la referencia a la `lista_descuento_id` quede registrada en cada ítem. 
- Corregir comparaciones de IDs para que no fallen por diferencias de tipo entre `string` y `int`.

### Description
- En `app/Livewire/Venta/GestionVenta.php` se dejó que el valor de `descuento` sea el ingresado (`$descuento = (float) $this->descuento`) en lugar de forzarlo desde la `listaSeleccionada`, para respetar el descuento manual al re-agregar un producto. 
- La búsqueda del producto en el carrito ahora normaliza los IDs usando `(string)` en la comparación `collect($this->carrito)->search(fn($p) => (string)$p['id'] === (string)$idProd)`. 
- Al re-agregar un producto existente se suma la nueva cantidad a la anterior y se recalculan los subtotales usando la variable resuelta ` $descuento`, y se actualiza `lista_descuento_id` en el ítem. 
- Al añadir un producto nuevo se almacenan `descuento` y `lista_descuento_id` en el nuevo elemento y los subtotales se calculan usando ` $descuento`.

### Testing
- No se ejecutaron pruebas automáticas en esta rama (ninguna prueba automática fue solicitada ni corrida).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976cc5cc34483338a9830c98f2d902a)